### PR TITLE
Serve CodeMirror CSS and JS locally.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ and Fields with WTForms
 """
 from setuptools import setup
 
-__version__ = '1.0'
+__version__ = '1.1'
 __author__ = 'TROUVERIE Joachim'
 __contact__ = 'joachim.trouverie@linoame.fr'
 


### PR DESCRIPTION
Add a configuration option (CODEMIRROR_SERVE_LOCAL, inspired by
flask-boostrap's BOOTSTRAP_SERVE_LOCAL) to serve CodeMirror files from
flask (they must be placed in <app-static-dir>/codemirror/<version>/...)