### PR TITLE
Support actual versions of Flask and CodeMirror

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ The module needs to be initialized in the usual way and can be configured using 
       from flask import Flask
       from flask_codemirror import CodeMirror
       # mandatory
-      CODEMIRROR_LANGUAGES = ['python', 'html']
+      CODEMIRROR_LANGUAGES = ['python', 'yaml', 'htmlembedded']
       WTF_CSRF_ENABLED = True
       SECRET_KEY = 'secret'
       # optional
@@ -68,6 +68,7 @@ Finally, the template needs the support Javascript code added, by calling `codem
          </head>
          <body>
 	   <form method="POST">
+        {{ form.csrf_token }}
               {{ form.source_code }}
 	      <input type="submit" value="OK">
            </form>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ Finally, the template needs the support Javascript code added, by calling ``code
       </head>
       <body>
         <form method="POST">
+          {{ form.csrf_token }}
           {{ form.source_code }}
         </form>
       </body>

--- a/flask_codemirror/__init__.py
+++ b/flask_codemirror/__init__.py
@@ -61,7 +61,7 @@ class CodeMirrorHeaders(object):
         self.theme = config.get(self.__class__.THEME_KEY, None)
         self.languages = config.get(self.__class__.LANGUAGES_KEY, [])
         self.addons = config.get(self.__class__.ADDONS_KEY, None)
-        self.version = config.get(self.__class__.VERSION_KEY, '4.12.0')
+        self.version = config.get(self.__class__.VERSION_KEY, '5.61.0')
         # construct base url
         self.base_url = self.__class__.CDN_URL.format(self.version)
         if not self.languages:

--- a/flask_codemirror/widgets.py
+++ b/flask_codemirror/widgets.py
@@ -24,9 +24,9 @@
 from __future__ import print_function
 
 import json
-from flask import current_app
+from flask import current_app, Markup
 try:
-    from wtforms.widgets import HTMLString, TextArea
+    from wtforms.widgets import TextArea
 except ImportError as exc:
     print('WTForms is required by Flask-Codemirror')
     raise exc
@@ -65,7 +65,7 @@ class CodeMirrorWidget(TextArea):
                                                       **kwargs)
         content = self._generate_content()
         post_html = self.__class__.POST_HTML.format(field.id, content)
-        return HTMLString(html + post_html)
+        return html + Markup(post_html)
 
     def _generate_content(self):
         """Dumps content using JSON to send to CodeMirror"""

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ and Fields with WTForms
 """
 from setuptools import setup
 
-__version__ = '1.1'
+__version__ = '1.2'
 __author__ = 'TROUVERIE Joachim'
 __contact__ = 'joachim.trouverie@linoame.fr'
 
@@ -38,7 +38,6 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Framework :: Flask',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/test.py
+++ b/test.py
@@ -24,7 +24,7 @@
 import unittest
 
 from flask import Flask, render_template_string
-from flask.ext.wtf import Form
+from flask_wtf import FlaskForm
 from flask_codemirror import CodeMirror, CodeMirrorConfigException
 from flask_codemirror.fields import CodeMirrorField
 
@@ -38,7 +38,7 @@ app = Flask(__name__)
 CODEMIRROR_LANGUAGES = ['python']
 CODEMIRROR_THEME = '3024-day'
 CODEMIRROR_ADDONS = (('dialog', 'dialog'), ('mode', 'overlay'))
-CODEMIRROR_VERSION = '4.12.0'
+CODEMIRROR_VERSION = '5.61.0'
 SECRET_KEY = 'secret!'
 app.config.from_object(__name__)
 
@@ -46,7 +46,7 @@ app.config.from_object(__name__)
 codemirror = CodeMirror(app)
 
 
-class MyForm(Form):
+class MyForm(FlaskForm):
     code = CodeMirrorField(language='python', id='test',
                            config={'linenumbers': True})
 
@@ -70,58 +70,58 @@ class FlaskCodeMirrorTest(unittest.TestCase):
     def test_head(self):
         response = self.app.get('/')
         self.assertIn(
-            '<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/4.12.0/codemirror.js"></script>',
+            b'<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.61.0/codemirror.js"></script>',
             response.data
         )
         self.assertIn(
-            '<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/4.12.0/codemirror.css">',
+            b'<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.61.0/codemirror.css">',
             response.data
         )
         self.assertIn(
-            '<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/4.12.0/mode/python/python.js"></script>',
+            b'<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.61.0/mode/python/python.js"></script>',
             response.data
         )
         self.assertIn(
-            '<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/4.12.0/theme/3024-day.css">',
+            b'<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.61.0/theme/3024-day.css">',
             response.data
         )
         self.assertIn(
-            '<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/4.12.0/theme/3024-day.css">',
+            b'<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.61.0/theme/3024-day.css">',
             response.data
         )
         self.assertIn(
-            '<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/4.12.0/addon/dialog/dialog.css">',
+            b'<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.61.0/addon/dialog/dialog.css">',
             response.data
         )
         self.assertIn(
-            '<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/4.12.0/addon/dialog/dialog.js"></script>',
+            b'<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.61.0/addon/dialog/dialog.js"></script>',
             response.data
         )
         self.assertNotIn(
-            '<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/4.12.0/addon/mode/overlay.css">',
+            b'<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.61.0/addon/mode/overlay.css">',
             response.data
         )
         self.assertIn(
-            '<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/4.12.0/addon/mode/overlay.js"></script>',
+            b'<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.61.0/addon/mode/overlay.js"></script>',
             response.data
         )
 
     def test_form(self):
         response = self.app.get('/form/')
         self.assertIn(
-            '<textarea id="flask-codemirror-test" name="code">',
+            b'<textarea id="flask-codemirror-test" name="code">',
             response.data
         )
         self.assertIn(
-            'var editor_for_test = CodeMirror.fromTextArea(',
+            b'var editor_for_test = CodeMirror.fromTextArea(',
             response.data
         )
         self.assertIn(
-            'document.getElementById(\'flask-codemirror-test\')',
+            b'document.getElementById(\'flask-codemirror-test\')',
             response.data
         )
         self.assertIn(
-            '"linenumbers": true',
+            b'"linenumbers": true',
             response.data
         )
 


### PR DESCRIPTION
Hi Joachim

There are some minor changes required to run your code on actual versions.
I tested:
- The example as explained in the readme.
- I was running python test.py successfully.

The code is really helpful for me, thank you
   Hans