### PR TITLE
Use markupsafe directly

### DIFF
--- a/flask_codemirror/__init__.py
+++ b/flask_codemirror/__init__.py
@@ -25,7 +25,8 @@
 
 import requests
 import warnings
-from flask import current_app, Markup
+from flask import current_app
+from markupsafe import Markup
 
 try:
     from urllib.parse import urljoin

--- a/flask_codemirror/widgets.py
+++ b/flask_codemirror/widgets.py
@@ -24,7 +24,8 @@
 from __future__ import print_function
 
 import json
-from flask import current_app, Markup
+from flask import current_app
+from markupsafe import Markup
 
 try:
     from wtforms.widgets import TextArea


### PR DESCRIPTION
Since flask 3.0.0 Markup is no longer re-exported from markupsafe.